### PR TITLE
Fix 'recipe already exists' where the existing_slug was checked again…

### DIFF
--- a/mealie-auto-tagger.py
+++ b/mealie-auto-tagger.py
@@ -125,7 +125,7 @@ class MealieAutoTagger:
         for item in items:
             existing_name = item.get('name', '').lower()
             existing_slug = item.get('slug', '').lower()
-            if existing_slug == item_slug or existing_name == name.lower() or existing_slug == self._slugify(existing_name):
+            if existing_slug == item_slug or existing_name == name.lower() or existing_slug == item_slug:
                 return item
         
         # 3. Create it if it doesn't exist


### PR DESCRIPTION
Fix for 'recipe already exists' (issue #1) where the existing_slug was checked against the existing named slug when it should be checking against item_slug